### PR TITLE
Convert middleware once instead of doing it during routing

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@ KoaBetterRouter.prototype.createRoute = function createRoute (method, route, fns
     route: route,
     match: this.route(prefixed),
     method: method,
-    middlewares: middlewares
+    middlewares: middlewares.map((fn) => utils.isGenerator(fn) ? utils.convert(fn) : fn)
   }
 }
 
@@ -531,9 +531,6 @@ KoaBetterRouter.prototype.middleware = function middleware () {
       }
 
       route.params = match
-      route.middlewares = route.middlewares.map((fn) => {
-        return utils.isGenerator(fn) ? utils.convert(fn) : fn
-      })
 
       // may be useful for the user
       ctx.route = route


### PR DESCRIPTION
I'm not sure if there is reasoning for that... 
But as of now alignment of different kinds of middlewares is done upon routing.
I believe it might be fairly ineffective to do it all the time, especially if number of middlewares is high.

Since route can be created only at `.createRoute` method i moved it there.
But i'm not sure if user is allowed to modify middlewares of route.
If it is allowed then, i suppose conversion is required at routing time, still it is fairly bad from my point of view.

**Tests are passed locally.**