### PR TITLE
refactor(options): Validate options.notFound during initialization

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,6 +60,11 @@ function KoaBetterRouter (options) {
   }
 
   this.options = utils.extend({ prefix: '/' }, options)
+  if ('notFound' in this.options &&
+      typeof this.options.notFound !== 'function') {
+    throw new TypeError('option notFound can be only a function')
+  }
+
   this.route = utils.pathMatch(this.options)
   this.routes = []
 }
@@ -548,7 +553,7 @@ KoaBetterRouter.prototype.middleware = function middleware () {
     }
     // called when request path not found on routes
     // ensure calling next middleware which is after the router
-    return typeof this.options.notFound === 'function'
+    return this.options.notFound !== undefined
       ? this.options.notFound(ctx, next)
       : next()
   }

--- a/test.js
+++ b/test.js
@@ -400,3 +400,14 @@ test('should call options.notFound(ctx, next) if route not found', (done) => {
     .expect('ok not found')
     .expect(404, done)
 })
+
+test('should throw on invalid options.notFound', (done) => {
+  function init () {
+    return Router({
+      notFound: 'invalid'
+    })
+  }
+
+  test.throws(init, Error)
+  done()
+})


### PR DESCRIPTION
I think it would be better to do a proper validation at initialize time.
After all user expected to use a proper options.

And sorry, but for some reason `git cz` doesn't work well with my msys2 setup.
I guess it is a bit confused with paths used by msys2 git.
`npm run commit` fails for me :(

As usual all tests are passed locally