### PR TITLE
[MAINT] update example code to match its description

### DIFF
--- a/recipes/route-objects/README.md
+++ b/recipes/route-objects/README.md
@@ -72,14 +72,11 @@ Let's see usage of `.addRoutes` and `.createRoute`/`.getRoute` in second example
 
 ```js
 let router = require('koa-better-router')()
-let extend = require('extend-shallow')
 
-router.createRoute('GET /foo', (ctx, next) => {})
-
-let foo = router.getRoute('/foo')
+let foo = router.createRoute('GET /foo', (ctx, next) => {})
 console.log(foo)
 
-let foo22 = extend({}, foo)
+let foo22 = router.getRoute('/foo')
 console.log(foo22) // same as above
 
 // let's change `foo22` a bit

--- a/recipes/route-objects/README.md
+++ b/recipes/route-objects/README.md
@@ -74,7 +74,9 @@ Let's see usage of `.addRoutes` and `.createRoute`/`.getRoute` in second example
 let router = require('koa-better-router')()
 let extend = require('extend-shallow')
 
-let foo = router.createRoute('GET /foo', (ctx, next) => {})
+router.createRoute('GET /foo', (ctx, next) => {})
+
+let foo = router.getRoute('/foo')
 console.log(foo)
 
 let foo22 = extend({}, foo)


### PR DESCRIPTION
Item 2 of [example 3][example-3] mentions having used `.getRoute` but the example code isn't actually using `.getRoute`

[example-3]: https://github.com/tunnckoCore/koa-better-router/blob/master/recipes/route-objects/README.md#example-3